### PR TITLE
Add more macro calculation tests

### DIFF
--- a/test/calculation.test.js
+++ b/test/calculation.test.js
@@ -18,3 +18,54 @@ test('calculate macros for metric male example', () => {
   assert.ok(Math.abs(result.fatGrams - 80) < 0.1);
   assert.ok(Math.abs(result.carbsGrams - 333.75) < 0.01);
 });
+
+test('calculate macros for metric male lose goal', () => {
+  const result = calculateMacros({
+    sex: 'male',
+    age: 30,
+    height: 180,
+    weight: 80,
+    activity: 1.55,
+    goal: 'lose',
+    system: 'metric'
+  });
+
+  assert.ok(Math.abs(result.calories - 2259) < 1);
+  assert.ok(Math.abs(result.proteinGrams - 176) < 0.1);
+  assert.ok(Math.abs(result.fatGrams - 80) < 0.1);
+  assert.ok(Math.abs(result.carbsGrams - 208.75) < 0.01);
+});
+
+test('calculate macros for metric male gain goal', () => {
+  const result = calculateMacros({
+    sex: 'male',
+    age: 30,
+    height: 180,
+    weight: 80,
+    activity: 1.55,
+    goal: 'gain',
+    system: 'metric'
+  });
+
+  assert.ok(Math.abs(result.calories - 3059) < 1);
+  assert.ok(Math.abs(result.proteinGrams - 176) < 0.1);
+  assert.ok(Math.abs(result.fatGrams - 80) < 0.1);
+  assert.ok(Math.abs(result.carbsGrams - 408.75) < 0.01);
+});
+
+test('calculate macros for imperial male example', () => {
+  const result = calculateMacros({
+    sex: 'male',
+    age: 30,
+    height: 71,
+    weight: 176,
+    activity: 1.55,
+    goal: 'maintain',
+    system: 'imperial'
+  });
+
+  assert.ok(Math.abs(result.calories - 2759.69) < 1);
+  assert.ok(Math.abs(result.proteinGrams - 175.63) < 0.1);
+  assert.ok(Math.abs(result.fatGrams - 79.83) < 0.1);
+  assert.ok(Math.abs(result.carbsGrams - 334.67) < 0.01);
+});


### PR DESCRIPTION
## Summary
- expand `test/calculation.test.js` with cases for `lose`, `gain`, and an imperial example

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fe5618ffc8320a87c3a39573a489f