### PR TITLE
Implement multilingual UI and custom macros

### DIFF
--- a/calculator.js
+++ b/calculator.js
@@ -1,4 +1,4 @@
-function calculateMacros({sex, age, height, weight, activity, goal, system}) {
+function calculateMacros({sex, age, height, weight, activity, goal, system, ratios}) {
   if (system === 'imperial') {
     height *= 2.54;
     weight *= 0.453592;
@@ -22,12 +22,24 @@ function calculateMacros({sex, age, height, weight, activity, goal, system}) {
     finalCalories = maintenanceCalories;
   }
 
-  const proteinGrams = weight * 2.2;
-  const fatGrams = weight * 1;
-  const proteinCalories = proteinGrams * 4;
-  const fatCalories = fatGrams * 9;
-  const carbsCalories = finalCalories - (proteinCalories + fatCalories);
-  const carbsGrams = carbsCalories / 4;
+  let proteinGrams, fatGrams, carbsGrams;
+  let proteinCalories, fatCalories, carbsCalories;
+
+  if (ratios) {
+    proteinCalories = finalCalories * (ratios.protein / 100);
+    fatCalories = finalCalories * (ratios.fat / 100);
+    carbsCalories = finalCalories * (ratios.carbs / 100);
+    proteinGrams = proteinCalories / 4;
+    fatGrams = fatCalories / 9;
+    carbsGrams = carbsCalories / 4;
+  } else {
+    proteinGrams = weight * 2.2;
+    fatGrams = weight * 1;
+    proteinCalories = proteinGrams * 4;
+    fatCalories = fatGrams * 9;
+    carbsCalories = finalCalories - (proteinCalories + fatCalories);
+    carbsGrams = carbsCalories / 4;
+  }
 
   const total = proteinCalories + fatCalories + carbsCalories;
   const pPct = (proteinCalories / total) * 100;

--- a/index.html
+++ b/index.html
@@ -11,36 +11,41 @@
 </head>
 <body>
   <button id="toggleDarkMode" class="dark-mode-btn">🌙 Dark Mode</button>
+  <label id="languageLabel" for="language">Language:</label>
+  <select id="language" class="language-select">
+    <option value="en">English</option>
+    <option value="es">Español</option>
+  </select>
 
   <div class="container">
     <h1>Macro Calculator</h1>
 
     <form id="macroForm">
-      <label>System:</label>
+      <label id="systemLabel">System:</label>
       <div class="unit-buttons">
         <button type="button" id="metricBtn" class="unit-btn active">Metric</button>
         <button type="button" id="imperialBtn" class="unit-btn">Imperial</button>
       </div>
 
-      <label>Sex:</label>
+      <label id="sexLabel">Sex:</label>
       <select id="sex">
         <option value="male">Male</option>
         <option value="female">Female</option>
       </select>
 
-      <label>Age:</label>
+      <label id="ageLabel">Age:</label>
       <input type="number" id="age" required />
       <small class="error-message" id="ageError"></small>
 
-      <label>Height:</label>
+      <label id="heightLabel">Height:</label>
       <input type="number" id="height" required placeholder="cm" />
       <small class="error-message" id="heightError"></small>
 
-      <label>Weight:</label>
+      <label id="weightLabel">Weight:</label>
       <input type="number" id="weight" required placeholder="kg" />
       <small class="error-message" id="weightError"></small>
 
-      <label>Activity Level:</label>
+      <label id="activityLabel">Activity Level:</label>
       <select id="activity">
         <option value="1.2">Sedentary or very little exercise</option>
         <option value="1.375">Moderate exercise 1–3 days per week</option>
@@ -50,14 +55,24 @@
         <option value="1.9">Very intense exercise 6–7 days per week or physically demanding job</option>
       </select>
 
-      <label>Goal:</label>
+      <label id="goalLabel">Goal:</label>
       <select id="goal">
         <option value="lose">Lose Fat</option>
         <option value="maintain">Maintain</option>
         <option value="gain">Gain Muscle</option>
       </select>
 
-      <button type="submit">Calculate</button>
+      <label id="proteinLabel">Protein %:</label>
+      <input type="number" id="proteinRatio" value="30" min="0" max="100" />
+
+      <label id="fatLabel">Fat %:</label>
+      <input type="number" id="fatRatio" value="25" min="0" max="100" />
+
+      <label id="carbLabel">Carbs %:</label>
+      <input type="number" id="carbRatio" value="45" min="0" max="100" />
+      <small class="error-message" id="ratioError"></small>
+
+      <button type="submit" id="calculateBtn">Calculate</button>
     </form>
 
     <div id="results" class="fade-in"></div>

--- a/script.js
+++ b/script.js
@@ -1,7 +1,138 @@
 let currentUnit = 'metric';
+let currentLang = 'en';
+
+const translations = {
+  en: {
+    title: 'Macro Calculator',
+    system: 'System:',
+    metric: 'Metric',
+    imperial: 'Imperial',
+    sex: 'Sex:',
+    male: 'Male',
+    female: 'Female',
+    age: 'Age:',
+    height: 'Height:',
+    weight: 'Weight:',
+    activity: 'Activity Level:',
+    activity1: 'Sedentary or very little exercise',
+    activity2: 'Moderate exercise 1\u20133 days per week',
+    activity3: 'Moderate exercise 4\u20135 days per week',
+    activity4: 'Moderate exercise 7 days per week or intense exercise 3\u20134 times per week',
+    activity5: 'Intense exercise 6\u20137 days per week',
+    activity6: 'Very intense exercise 6\u20137 days per week or physically demanding job',
+    goal: 'Goal:',
+    lose: 'Lose Fat',
+    maintain: 'Maintain',
+    gain: 'Gain Muscle',
+    protein: 'Protein %:',
+    fat: 'Fat %:',
+    carbs: 'Carbs %:',
+    calculate: 'Calculate',
+    estCalories: 'Estimated Daily Calories',
+    proteinW: 'Protein',
+    fatW: 'Fat',
+    carbsW: 'Carbohydrates',
+    copy: '📋 Copy Result',
+    language: 'Language:',
+    ageMin: 'Age must be at least 18.',
+    heightMin: 'Height must be at least {min} {unit}.',
+    weightMin: 'Weight must be at least {min} {unit}.',
+    ratioSum: 'Ratios must total 100%.',
+    copied: 'Result copied to clipboard!',
+    dark: '🌙 Dark Mode',
+    light: '☀️ Light Mode'
+  },
+  es: {
+    title: 'Calculadora de Macronutrientes',
+    system: 'Sistema:',
+    metric: 'Métrico',
+    imperial: 'Imperial',
+    sex: 'Sexo:',
+    male: 'Hombre',
+    female: 'Mujer',
+    age: 'Edad:',
+    height: 'Altura:',
+    weight: 'Peso:',
+    activity: 'Nivel de actividad:',
+    activity1: 'Sedentario o muy poco ejercicio',
+    activity2: 'Ejercicio moderado 1\u20133 d\xedas por semana',
+    activity3: 'Ejercicio moderado 4\u20135 d\xedas por semana',
+    activity4: 'Ejercicio moderado 7 d\xedas o intenso 3\u20134 veces por semana',
+    activity5: 'Ejercicio intenso 6\u20137 d\xedas por semana',
+    activity6: 'Ejercicio muy intenso 6\u20137 d\xedas o trabajo f\xedsicamente demandante',
+    goal: 'Objetivo:',
+    lose: 'Perder grasa',
+    maintain: 'Mantener',
+    gain: 'Ganar músculo',
+    protein: 'Proteína %:',
+    fat: 'Grasa %:',
+    carbs: 'Carbohidratos %:',
+    calculate: 'Calcular',
+    estCalories: 'Calor\u00edas diarias estimadas',
+    proteinW: 'Prote\u00ednas',
+    fatW: 'Grasas',
+    carbsW: 'Carbohidratos',
+    copy: '📋 Copiar resultado',
+    language: 'Idioma:',
+    ageMin: 'La edad mínima es 18.',
+    heightMin: 'La altura mínima es {min} {unit}.',
+    weightMin: 'El peso mínimo es {min} {unit}.',
+    ratioSum: 'Los porcentajes deben sumar 100%.',
+    copied: '¡Resultado copiado!',
+    dark: '🌙 Modo oscuro',
+    light: '☀️ Modo claro'
+  }
+};
 
 const metricBtn = document.getElementById('metricBtn');
 const imperialBtn = document.getElementById('imperialBtn');
+const languageSelect = document.getElementById('language');
+const toggleBtn = document.getElementById('toggleDarkMode');
+const calculateBtn = document.getElementById('calculateBtn');
+const copyBtn = document.getElementById('copyBtn');
+
+function applyTranslations() {
+  const t = translations[currentLang];
+  document.querySelector('h1').textContent = t.title;
+  document.getElementById('systemLabel').textContent = t.system;
+  metricBtn.textContent = t.metric;
+  imperialBtn.textContent = t.imperial;
+  document.getElementById('sexLabel').textContent = t.sex;
+  document.querySelector('#sex option[value="male"]').textContent = t.male;
+  document.querySelector('#sex option[value="female"]').textContent = t.female;
+  document.getElementById('ageLabel').textContent = t.age;
+  document.getElementById('heightLabel').textContent = t.height;
+  document.getElementById('weightLabel').textContent = t.weight;
+  document.getElementById('activityLabel').textContent = t.activity;
+  const act = document.querySelectorAll('#activity option');
+  if (act.length >= 6) {
+    act[0].textContent = t.activity1;
+    act[1].textContent = t.activity2;
+    act[2].textContent = t.activity3;
+    act[3].textContent = t.activity4;
+    act[4].textContent = t.activity5;
+    act[5].textContent = t.activity6;
+  }
+  document.getElementById('goalLabel').textContent = t.goal;
+  document.querySelector('#goal option[value="lose"]').textContent = t.lose;
+  document.querySelector('#goal option[value="maintain"]').textContent = t.maintain;
+  document.querySelector('#goal option[value="gain"]').textContent = t.gain;
+  document.getElementById('proteinLabel').textContent = t.protein;
+  document.getElementById('fatLabel').textContent = t.fat;
+  document.getElementById('carbLabel').textContent = t.carbs;
+  calculateBtn.textContent = t.calculate;
+  copyBtn.textContent = t.copy;
+  document.getElementById('languageLabel').textContent = t.language;
+  const isDark = document.body.classList.contains('dark');
+  toggleBtn.textContent = isDark ? t.light : t.dark;
+}
+
+languageSelect.addEventListener('change', () => {
+  currentLang = languageSelect.value;
+  applyTranslations();
+});
+
+window.addEventListener('DOMContentLoaded', applyTranslations);
 
 metricBtn.addEventListener('click', () => {
   currentUnit = 'metric';
@@ -25,10 +156,14 @@ function validateInputs() {
   const age = parseInt(document.getElementById('age').value);
   const height = parseFloat(document.getElementById('height').value);
   const weight = parseFloat(document.getElementById('weight').value);
+  const pRatio = parseFloat(document.getElementById('proteinRatio').value);
+  const fRatio = parseFloat(document.getElementById('fatRatio').value);
+  const cRatio = parseFloat(document.getElementById('carbRatio').value);
 
   const ageError = document.getElementById('ageError');
   const heightError = document.getElementById('heightError');
   const weightError = document.getElementById('weightError');
+  const ratioError = document.getElementById('ratioError');
 
   const minHeightMetric = 100;
   const minWeightMetric = 30;
@@ -45,7 +180,7 @@ function validateInputs() {
   }
 
   if (isNaN(age) || age < 18) {
-    ageError.textContent = "Age must be at least 18.";
+    ageError.textContent = translations[currentLang].ageMin;
     ageError.style.display = "block";
     document.getElementById('age').classList.add('invalid');
     valid = false;
@@ -56,7 +191,9 @@ function validateInputs() {
 
   if (isNaN(height) || height < minHeight) {
     const minHeightDisplay = Math.round(minHeight);
-    heightError.textContent = `Height must be at least ${minHeightDisplay} ${heightUnit}.`;
+    heightError.textContent = translations[currentLang].heightMin
+      .replace('{min}', minHeightDisplay)
+      .replace('{unit}', heightUnit);
     heightError.style.display = "block";
     document.getElementById('height').classList.add('invalid');
     valid = false;
@@ -67,13 +204,24 @@ function validateInputs() {
 
   if (isNaN(weight) || weight < minWeight) {
     const minWeightDisplay = Math.round(minWeight);
-    weightError.textContent = `Weight must be at least ${minWeightDisplay} ${weightUnit}.`;
+    weightError.textContent = translations[currentLang].weightMin
+      .replace('{min}', minWeightDisplay)
+      .replace('{unit}', weightUnit);
     weightError.style.display = "block";
     document.getElementById('weight').classList.add('invalid');
     valid = false;
   } else {
     weightError.style.display = "none";
     document.getElementById('weight').classList.remove('invalid');
+  }
+
+  const totalRatio = pRatio + fRatio + cRatio;
+  if (isNaN(totalRatio) || Math.round(totalRatio) !== 100) {
+    ratioError.textContent = translations[currentLang].ratioSum;
+    ratioError.style.display = 'block';
+    valid = false;
+  } else {
+    ratioError.style.display = 'none';
   }
 
   return valid;
@@ -91,13 +239,27 @@ document.getElementById('macroForm').addEventListener('submit', function (e) {
   const goal = document.getElementById('goal').value;
   const system = currentUnit;
 
-  const result = calculateMacros({ sex, age, height, weight, activity, goal, system });
+  const proteinRatio = parseFloat(document.getElementById('proteinRatio').value);
+  const fatRatio = parseFloat(document.getElementById('fatRatio').value);
+  const carbRatio = parseFloat(document.getElementById('carbRatio').value);
 
+  const result = calculateMacros({
+    sex,
+    age,
+    height,
+    weight,
+    activity,
+    goal,
+    system,
+    ratios: { protein: proteinRatio, fat: fatRatio, carbs: carbRatio }
+  });
+
+  const t = translations[currentLang];
   const resultText =
-    `Estimated Daily Calories: ${result.calories.toFixed(0)} kcal\n` +
-    `Protein: ${result.proteinGrams.toFixed(0)} g (${result.proteinPercent.toFixed(0)}%)\n` +
-    `Fat: ${result.fatGrams.toFixed(0)} g (${result.fatPercent.toFixed(0)}%)\n` +
-    `Carbohydrates: ${result.carbsGrams.toFixed(0)} g (${result.carbsPercent.toFixed(0)}%)`;
+    `${t.estCalories}: ${result.calories.toFixed(0)} kcal\n` +
+    `${t.proteinW}: ${result.proteinGrams.toFixed(0)} g (${result.proteinPercent.toFixed(0)}%)\n` +
+    `${t.fatW}: ${result.fatGrams.toFixed(0)} g (${result.fatPercent.toFixed(0)}%)\n` +
+    `${t.carbsW}: ${result.carbsGrams.toFixed(0)} g (${result.carbsPercent.toFixed(0)}%)`;
 
   const resultsDiv = document.getElementById('results');
   resultsDiv.classList.remove('fade-in');
@@ -109,7 +271,14 @@ document.getElementById('macroForm').addEventListener('submit', function (e) {
 
   // Guardar última sesión
   const data = {
-    sex, age, height, weight, activity, goal, unit: currentUnit
+    sex,
+    age,
+    height,
+    weight,
+    activity,
+    goal,
+    unit: currentUnit,
+    ratios: { protein: proteinRatio, fat: fatRatio, carbs: carbRatio }
   };
   localStorage.setItem('macroData', JSON.stringify(data));
 });
@@ -118,7 +287,7 @@ document.getElementById('macroForm').addEventListener('submit', function (e) {
 document.getElementById('copyBtn').addEventListener('click', () => {
   const text = document.getElementById('results').textContent;
   navigator.clipboard.writeText(text);
-  alert("Result copied to clipboard!");
+  alert(translations[currentLang].copied);
 });
 
 // RECUPERAR DATOS
@@ -132,26 +301,32 @@ window.addEventListener('DOMContentLoaded', () => {
   document.getElementById('weight').value = saved.weight;
   document.getElementById('activity').value = saved.activity;
   document.getElementById('goal').value = saved.goal;
+  if (saved.ratios) {
+    document.getElementById('proteinRatio').value = saved.ratios.protein;
+    document.getElementById('fatRatio').value = saved.ratios.fat;
+    document.getElementById('carbRatio').value = saved.ratios.carbs;
+  }
 
   if (saved.unit === 'imperial') {
     imperialBtn.click();
   } else {
     metricBtn.click();
   }
+
+  applyTranslations();
 });
 
 // MODO OSCURO
-const toggleBtn = document.getElementById('toggleDarkMode');
 const prefersDark = localStorage.getItem('theme') === 'dark';
 
 if (prefersDark) {
   document.body.classList.add('dark');
-  toggleBtn.textContent = '☀️ Light Mode';
 }
+toggleBtn.textContent = prefersDark ? translations[currentLang].light : translations[currentLang].dark;
 
 toggleBtn.addEventListener('click', () => {
   document.body.classList.toggle('dark');
   const isDark = document.body.classList.contains('dark');
-  toggleBtn.textContent = isDark ? '☀️ Light Mode' : '🌙 Dark Mode';
+  toggleBtn.textContent = isDark ? translations[currentLang].light : translations[currentLang].dark;
   localStorage.setItem('theme', isDark ? 'dark' : 'light');
 });

--- a/style.css
+++ b/style.css
@@ -207,6 +207,14 @@ body {
     cursor: pointer;
     transition: background 0.3s ease;
   }
+
+  .language-select {
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    padding: 8px;
+    font-size: 14px;
+  }
   
   .dark-mode-btn:hover {
     background: #0056b3;


### PR DESCRIPTION
## Summary
- add language selector and translations
- allow custom macro ratio inputs
- persist custom ratios in localStorage
- translate validation and result text
- add offline dark-mode text and translations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fe3f8e158832088b1c0e63c0e0f57