### PR TITLE
Add affiliate products page

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
 
     <div id="results" class="fade-in"></div>
   <button id="copyBtn" class="copy-button" style="display: none;">📋 Copy Result</button>
+  <a href="products.html" class="affiliate-btn">Recommended Products</a>
   </div>
 
   <footer>

--- a/products.html
+++ b/products.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Recommended Products</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Recommended Products</h1>
+    <ul class="product-list">
+      <li><a href="https://example.com/product1" target="_blank" rel="noopener noreferrer">Product 1</a></li>
+      <li><a href="https://example.com/product2" target="_blank" rel="noopener noreferrer">Product 2</a></li>
+      <li><a href="https://example.com/product3" target="_blank" rel="noopener noreferrer">Product 3</a></li>
+    </ul>
+    <a href="index.html" class="affiliate-btn">Back to Calculator</a>
+  </div>
+  <script>
+    if (localStorage.getItem('theme') === 'dark') {
+      document.body.classList.add('dark');
+    }
+  </script>
+</body>
+</html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -5,6 +5,7 @@ self.addEventListener('install', e => {
           './',
           './index.html',
           './style.css',
+          './products.html',
           './script.js',
           './calculator.js',
           './manifest.json',

--- a/style.css
+++ b/style.css
@@ -270,3 +270,46 @@ body {
     color: #000;
   }
   
+/* Affiliate button */
+.affiliate-btn {
+  display: inline-block;
+  margin-top: 20px;
+  padding: 12px 20px;
+  background-color: #007bff;
+  color: #fff;
+  border-radius: 6px;
+  text-decoration: none;
+  transition: background 0.3s ease;
+}
+
+.affiliate-btn:hover {
+  background-color: #0056b3;
+}
+
+/* Product list */
+.product-list {
+  list-style: none;
+  padding: 0;
+}
+
+.product-list li {
+  margin-bottom: 10px;
+}
+
+.product-list a {
+  color: #007bff;
+  text-decoration: underline;
+}
+
+body.dark .affiliate-btn {
+  background-color: #333;
+  color: #f1f1f1;
+}
+
+body.dark .affiliate-btn:hover {
+  background-color: #555;
+}
+
+body.dark .product-list a {
+  color: #4ea3ff;
+}


### PR DESCRIPTION
## Summary
- add new `products.html` page with affiliate links
- link to products page from the calculator
- style affiliate button and product list
- cache the new page in `service-worker.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851cf4fbd448320851c6b70b459bd1f